### PR TITLE
fix(opener): emit every ring, not just the first one

### DIFF
--- a/lib/library.js
+++ b/lib/library.js
@@ -612,6 +612,21 @@ class Library {
     }
 
     /**
+     * Invalidate the cached value of a single state.
+     *
+     * _setValue() deduplicates writes against the internal cache. For event-like
+     * states (e.g. a doorbell ring) the very same value may legitimately occur
+     * again and must still be written, otherwise consumers never see the repeated
+     * event. Invalidating the cached entry lets the next write pass through.
+     *
+     * @param	{string}	state	State to invalidate
+     * @returns	void
+     */
+    invalidateDeviceState(state) {
+        delete this._STATES[state];
+    }
+
+    /**
      * Reset all states.
      *
      * @param	void

--- a/lib/nuki-tools.js
+++ b/lib/nuki-tools.js
@@ -185,6 +185,20 @@ class NukiTools {
             payload.state.lastStateUpdate = Date.now();
         }
 
+        // A ring is an event, not a status. Nuki reports ringactionState = true again
+        // for every ring while ringactionTimestamp advances each time. Because
+        // library._setValue() deduplicates against its internal cache, a repeated
+        // "true" is swallowed and consumers never see the second ring (e.g. parcel
+        // service ringing shortly after the postman). Whenever a newer ring timestamp
+        // arrives, invalidate the cached ringState so the event is written through.
+        if (
+            payload.state &&
+            payload.state.ringactionTimestamp &&
+            payload.state.ringactionTimestamp !== library.getDeviceState(`${path}.state.ringStateUpdate`)
+        ) {
+            library.invalidateDeviceState(`${path}.state.ringState`);
+        }
+
         // remove unnecessary states
         if (payload.state && payload.state.stateName) {
             delete payload.state.stateName;


### PR DESCRIPTION
## Problem

The Opener's ring is an **event**, not a status. Nuki reports `state.ringactionState = true` again for every ring, while `state.ringactionTimestamp` advances each time.

`Library._setValue()` deduplicates writes against its internal `_STATES` cache:

https://github.com/iobroker-community-adapters/ioBroker.nuki-extended/blob/master/lib/library.js#L597-L612

```js
if (value !== undefined && (options.force || this._STATES[state] === undefined ||
    this._STATES[state] === null || this._STATES[state].val != value)) {
    this._adapter.setStateAsync(state, { val: value, ts: Date.now(), ack: true });
} else {
    this.setDeviceProperties(state);   // nothing is written
}
```

Because the value is `true` both times, the second ring is swallowed and `state.ringState` is never written again. Anything subscribing to that state misses every ring after the first.

There is a second, related effect: the cache can **drift from the actual state**. If `ringState` is written from outside the adapter — a script resetting it to `false`, a VIS widget, a manual change — the adapter still believes the value is `true` and suppresses all further writes until it is restarted.

### How to reproduce

1. Subscribe to `<instance>.openers.<opener>.state.ringState`.
2. Ring the doorbell — the state turns `true`, the subscription fires.
3. Ring again a few minutes later — no write, no event.

Real-world symptom: the postman rings and the announcement plays; the parcel service rings minutes later and nothing happens. It works again after an adapter restart (cache reset) or if Nuki happens to report `false` in between, which is why it looks intermittent.

`state.ringStateUpdate` (the timestamp) is unaffected and can be used as a workaround, but `ringState` is the obvious state to subscribe to and currently misleads consumers.

## Fix

Whenever a newer `ringactionTimestamp` arrives in `NukiTools.updateDevice()`, invalidate the cached `ringState` entry so the event is written through. This is deliberately scoped to an actual new ring, so it cannot cause repeated writes on regular polling cycles, and it leaves every other state untouched.

Adds a small `Library.invalidateDeviceState()` helper for that purpose, mirroring the existing `resetStates()`.

## Notes

- No behaviour change unless a genuinely new ring timestamp arrives.
- Verified against adapter 2.8.2 running on js-controller 7.2.2 (Nuki Opener via Web API), where the issue is reproducible.
- I could not run the integration tests against real hardware; review of the timestamp comparison would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)